### PR TITLE
Upgrade fixes, direct support for user_id

### DIFF
--- a/addon/services/intercom.js
+++ b/addon/services/intercom.js
@@ -8,10 +8,14 @@ import intercom from 'intercom';
 export default Service.extend({
   init() {
     this._super(...arguments);
-    set(this, "user", { name: null, email: null });
+    set(this, "user", { email: null, name: null, user_id: null });
   },
 
   api: intercom,
+
+  _userIdProp: computed('config.userProperties.userIdProp', function() {
+    return get(this, `user.${get(this, 'config.userProperties.userIdProp')}`);
+  }),
 
   _userNameProp: computed('config.userProperties.nameProp', function() {
     return get(this, `user.${get(this, 'config.userProperties.nameProp')}`);
@@ -28,7 +32,8 @@ export default Service.extend({
   user: null,
 
   _hasUserContext: computed('user', '_userNameProp', '_userEmailProp', '_userCreatedAtProp', function() {
-    return !!get(this, 'user') && !!get(this, '_userNameProp') && !!get(this, '_userEmailProp');
+    return !!get(this, 'user') && !!get(this, '_userNameProp') &&
+      (!!get(this, '_userEmailProp') || !!get(this, "_userIdProp"));
   }),
 
   _intercomBootConfig: computed('_hasUserContext', function() {
@@ -40,6 +45,7 @@ export default Service.extend({
     };
 
     if (get(this, '_hasUserContext')) {
+      obj.user_id = get(this, '_userIdProp');
       obj.name = get(this, '_userNameProp');
       obj.email = get(this, '_userEmailProp');
       if (get(this, '_userCreatedAtProp')) {

--- a/addon/services/intercom.js
+++ b/addon/services/intercom.js
@@ -1,11 +1,16 @@
 import { merge } from '@ember/polyfills';
 import Service from '@ember/service';
-import { computed, get } from '@ember/object';
+import { computed, get, set } from '@ember/object';
 import { assert } from '@ember/debug';
 import { scheduleOnce } from '@ember/runloop';
 import intercom from 'intercom';
 
 export default Service.extend({
+  init() {
+    this._super(...arguments);
+    set(this, "user", { name: null, email: null });
+  },
+
   api: intercom,
 
   _userNameProp: computed('config.userProperties.nameProp', function() {
@@ -20,11 +25,7 @@ export default Service.extend({
     return get(this, `user.${get(this, 'config.userProperties.createdAtProp')}`);
   }),
 
-  // eslint-disable-next-line
-  user: {
-    name: null,
-    email: null
-  },
+  user: null,
 
   _hasUserContext: computed('user', '_userNameProp', '_userEmailProp', '_userCreatedAtProp', function() {
     return !!get(this, 'user') && !!get(this, '_userNameProp') && !!get(this, '_userEmailProp');

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,9 +5,10 @@ module.exports = function(/* environment, appConfig */) {
     intercom: {
       appId: null,
       userProperties: {
-        nameProp: 'name',
+        createdAtProp: 'createdAt',
         emailProp: 'email',
-        createdAtProp: 'createdAt'
+        nameProp: 'name',
+        userIdProp: 'id'
       }
     }
   };

--- a/tests/integration/components/intercom-io-test.js
+++ b/tests/integration/components/intercom-io-test.js
@@ -16,6 +16,7 @@ const mockConfig = {
     userProperties: {
       nameProp: 'name',
       emailProp: 'email',
+      userIdProp: 'id',
       createdAtProp: 'createdAt'
     },
     appId: '1'

--- a/tests/unit/services/intercom-test.js
+++ b/tests/unit/services/intercom-test.js
@@ -1,7 +1,7 @@
 import { run } from '@ember/runloop';
 import { set } from '@ember/object';
 import { moduleFor } from 'ember-qunit';
-import test from 'dummy/tests/ember-sinon-qunit/test';
+import test from 'ember-sinon-qunit/test-support/test';
 import sinon from 'sinon';
 
 const mockConfig = {

--- a/tests/unit/services/intercom-test.js
+++ b/tests/unit/services/intercom-test.js
@@ -9,6 +9,7 @@ const mockConfig = {
     userProperties: {
       nameProp: 'name',
       emailProp: 'email',
+      userIdProp: 'id',
       createdAtProp: 'createdAt'
     },
     appId: '1'
@@ -30,6 +31,7 @@ moduleFor('service:intercom', 'Unit | Service | intercom', {
 
 test('it adds the correct user context to the boot config', function(assert) {
   let actualUser = {
+    id: 'fooUserId',
     name: 'foo',
     email: 'foo@foo.com',
     createdAt: new Date(),
@@ -38,6 +40,7 @@ test('it adds the correct user context to the boot config', function(assert) {
 
   let service = this.subject();
 
+  set(service.user, 'id', actualUser.id);
   set(service.user, 'email', actualUser.email);
   set(service.user, 'name', actualUser.name);
   set(service.user, 'createdAt', actualUser.createdAt);
@@ -53,6 +56,7 @@ test('it adds the correct user context to the boot config', function(assert) {
     app_id: mockConfig.intercom.appId, //eslint-disable-line
     name: actualUser.name,
     email: actualUser.email,
+    user_id: actualUser.id,
     created_at: actualUser.createdAt, //eslint-disable-line
     custom: actualUser.custom
   };


### PR DESCRIPTION
A follow-up to #134. I fixed the deprecated method of setting the `user` property to a fixed POJO and instead set it on init. Hopefully that's safe to do?

I fixed a deprecation warning on the sinon import, and added direct support for the Intercom `user_id` property.